### PR TITLE
Fix installation section of README + formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,28 @@ Python library for development of [SciData](http://stuchalk.github.io/scidata/) 
 *coming soon*!!!
 
 ### Manual (from source)
-Clone the repository
+Clone the repository either via:
+ - HTTP:
 ```
 git clone git@github.com:ChalkLab/SciDataLib.git
 ```
-or
+ - SSH:
 ```
 git clone https://github.com/ChalkLab/SciDataLib.git
 ```
 
-Create a virtual environment and activate to install package in.
+Create a virtual environment and activate to install the package in the isolated environment:
 ```
 python -m venv <name of env>
 source <env>/bin/activate
 ```
 
-To [install the library from the local source tree into the environment](https://packaging.python.org/tutorials/installing-packages/#installing-from-a-local-src-tree), run:
+To [install the package from the local source tree into the environment](https://packaging.python.org/tutorials/installing-packages/#installing-from-a-local-src-tree), run:
 ```
 python -m pip install .
 ```
 
-Or to do so in ["Development Mode"](), you can run:
+Or to do so in ["Development Mode"](https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode), you can run:
 ```
 python -m pip install -e .
 ```


### PR DESCRIPTION
Adding fixes missed in PR #16 that @JohnsonDylan caught.

Mainly, work includes:
 - the missing pip install commands for manual source installation
 - formatting fixes to the links and `git clone` command

To test:
 - Check that the manual installation works as described in the README.
 - All other changes are visual checks of the README on GitHub