### PR TITLE
Apply set to target to fix order in test context replace

### DIFF
--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -17,7 +17,7 @@ def test_context_replace():
     new_contexts = [
         'https://stuchalk.github.io/scidata/contexts/chembl.jsonld',
         'https://stuchalk.github.io/scidata/contexts/scidata.jsonld']
-    assert sd.context(new_contexts, True) == new_contexts
+    assert sd.context(new_contexts, True) == list(set(new_contexts))
 
 
 def test_namespace():


### PR DESCRIPTION
Closes #32

The order was different between result and target since a `list(set(...))``` was applied.
I see that you are taking out any duplicates to return only unique entries (great, nice catch!)
Yet, the `set` will re-order the list.
So the target list (`new_contents`) will keep the same order but the output will change order, failing the test.

I just applied the same operation to the outside `new_contexts` so it gets ordered the same way.