### PR TITLE
Disables coverage of cli code only for terminal

### DIFF
--- a/scidatalib/cli.py
+++ b/scidatalib/cli.py
@@ -38,7 +38,7 @@ def cli(input_args=None):
     if input_args:
         args = parser.parse_args(input_args)
     else:
-        args = parser.parse_args()
+        args = parser.parse_args()  # pragma: no cover
 
     sd = SciData(args.uid)
     with open(args.output, 'w') as out:
@@ -47,4 +47,4 @@ def cli(input_args=None):
 
 
 if __name__ == "__main__":
-    cli()
+    cli()  # pragma: no cover


### PR DESCRIPTION
This disables the two lines of code from coverage reporting that cannot really be tested since it needs to pull arguments from the shell.

You can see the difference between the coverage reports for the cli.py:
 - Before: https://github.com/ChalkLab/SciDataLib/runs/2202837966#step:7:25
 - After: https://github.com/ChalkLab/SciDataLib/runs/2203070647#step:7:25

Using the documentation from here to figure this out:
https://coverage.readthedocs.io/en/coverage-5.5/excluding.html