### PR TITLE
Removes reference to codecov token since no longer needed

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Coverage
         if: ${{ matrix.python-version == env.PYTHON_MAIN_VERSION }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
             poetry run pytest --cov=scidatalib --cov-report=term-missing tests/
             pip install coverage


### PR DESCRIPTION
Since the repository is now public, we no longer need the CODECOV_TOKEN, so removing it in the GitHub Actions yaml

NOTE: We also need to delete this from the GitHub Secrets as well. @stuchalk, I believe you will have to do this based on permissions.

To test:
 - This is the Actions pipeline that shows coverage upload passed: https://github.com/ChalkLab/SciDataLib/runs/2336335554?check_suite_focus=true
 - Also, this commit shows up as the most recent in the [CodeCov dashboard](https://app.codecov.io/gh/ChalkLab/SciDataLib) and the specific commit report is [here](https://codecov.io/gh/ChalkLab/SciDataLib/commit/f6a8e0f5f5fdc1197ee7f00af1e70cb76efb770a/)