### PR TITLE
Adds entry point for CLI in setup.py so cli is properly installed as "scidatalib"

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ scidatalib output.jsonld
 
 You can access the additional functionality via the `--help` option:
 ```
-scidata --help
+scidatalib --help
 ```
 
 ### SciDataLib library

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,9 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
+    entry_points={
+        'console_scripts': [
+            "scidatalib = scidatalib.cli:cli",
+        ]
+    }
 )


### PR DESCRIPTION
I forgot to add the entry point to the setup.py for the CLI so `pip install scidatalib` does not include the `scidatalib` command.
This will add it to the package.
Also small fix in the README for the CLI.