### PR TITLE
Added pypi badge + Releases to badges list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # SciDataLib
 
-| Health |
-|--------|
-| [![GitHub Actions](https://github.com/ChalkLab/SciDataLib/actions/workflows/actions.yml/badge.svg?branch=master)](https://github.com/ChalkLab/SciDataLib/actions/workflows/actions.yml) |
-| [![codecov](https://codecov.io/gh/ChalkLab/SciDataLib/branch/master/graph/badge.svg)](https://codecov.io/gh/ChalkLab/SciDataLib) |
-| [![DOI](https://zenodo.org/badge/219040010.svg)](https://zenodo.org/badge/latestdoi/219040010) |
+| Health | Releases |
+|--------|----------|
+| [![GitHub Actions](https://github.com/ChalkLab/SciDataLib/actions/workflows/actions.yml/badge.svg?branch=master)](https://github.com/ChalkLab/SciDataLib/actions/workflows/actions.yml) | [![PyPI version](https://badge.fury.io/py/SciDataLib.svg)](https://badge.fury.io/py/SciDataLib) |
+| [![codecov](https://codecov.io/gh/ChalkLab/SciDataLib/branch/master/graph/badge.svg)](https://codecov.io/gh/ChalkLab/SciDataLib) | [![DOI](https://zenodo.org/badge/219040010.svg)](https://zenodo.org/badge/latestdoi/219040010) |
 
 A Python library writing [SciData](http://stuchalk.github.io/scidata/) [JSON-LD](https://json-ld.org/) files.
 


### PR DESCRIPTION
Work includes:
 - Adding the PyPi badge for the release version
 - Adds a "Release" section to the badges for PyPi version and Zenodo DOI badge

To test:
 - [Go to branch](https://github.com/ChalkLab/SciDataLib/tree/add-pypi-badge) and look at README. Ensure badge layout looks okay