### PR TITLE
Add `io` module to setup translator design + fixes to CLI tests

### DIFF
--- a/scidatalib/io/__init__.py
+++ b/scidatalib/io/__init__.py
@@ -1,0 +1,6 @@
+from .formats import read, write
+
+__all__ = [
+    'read',
+    'write'
+]

--- a/scidatalib/io/formats.py
+++ b/scidatalib/io/formats.py
@@ -1,0 +1,54 @@
+"""Input/output module for reading + writing different file formats"""
+from importlib import import_module
+import types
+import typing
+
+
+_MODULE_BASE = 'scidatalib.io.'
+
+
+class UnknownFileTypeError(Exception):
+    pass
+
+
+ioformats = {
+    'jcamp': 'jcamp',
+    'rruff': 'rruff',
+    'scidata-jsonld': 'scidata_jsonld',
+}
+
+
+def _get_ioformat(name: str) -> types.ModuleType:
+    if name not in ioformats:
+        raise UnknownFileTypeError(name)
+    module = _MODULE_BASE + ioformats[name]
+    fmt = import_module(module)
+    return fmt
+
+
+def _readfunc(module: types.ModuleType, name: str) -> typing.Callable:
+    return getattr(module, 'read_' + name)
+
+
+def _writefunc(module: types.ModuleType, name: str) -> typing.Callable:
+    return getattr(module, 'write_' + name)
+
+
+def read(filename: str, ioformat: str = None, **kwargs) -> dict:
+    """
+    Read SciData dict from file format
+    """
+    module = _get_ioformat(ioformat)
+    function = _readfunc(module, ioformats.get(ioformat))
+    return function(filename, **kwargs)
+
+
+def write(
+    filename: str, scidata_dict: dict, ioformat: str = None, **kwargs
+) -> typing.Callable:
+    """
+    Write SciData dict to file format
+    """
+    module = _get_ioformat(ioformat)
+    function = _writefunc(module, ioformats.get(ioformat))
+    return function(filename, scidata_dict, **kwargs)

--- a/scidatalib/io/formats.py
+++ b/scidatalib/io/formats.py
@@ -12,9 +12,6 @@ class UnknownFileTypeError(Exception):
 
 
 ioformats = {
-    'jcamp': 'jcamp',
-    'rruff': 'rruff',
-    'scidata-jsonld': 'scidata_jsonld',
 }
 
 

--- a/tests/io/test_formats.py
+++ b/tests/io/test_formats.py
@@ -1,0 +1,8 @@
+"""Tests for io.formats"""
+import pytest
+from scidatalib import io
+
+
+def test_get_ioformat_raise_exception():
+    with pytest.raises(io.formats.UnknownFileTypeError):
+        io.formats._get_ioformat('cat')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,11 +4,13 @@ from scidatalib.cli import cli
 
 def test_scidatalib_cli(tmp_path):
     """Test for CLI 'bare' scidata jsonld"""
-    filename = tmp_path / "output.jsonld"
-    args = [filename.absolute().name]
+    output_dir = tmp_path / "scidatalib_cli"
+    output_dir.mkdir()
+    filename = output_dir / "output.jsonld"
+    args = [str(filename.resolve())]
     cli(args)
 
-    with open(filename.absolute().name, 'r') as f:
+    with open(filename.resolve(), 'r') as f:
         jsonld = json.load(f)
 
     assert '@context' in jsonld
@@ -40,10 +42,10 @@ def test_scidatalib_cli_uid(tmp_path):
     """Test for CLI changing UID"""
     filename = tmp_path / "output.jsonld"
     uid = "new_example"
-    args = [filename.absolute().name, "--uid", uid]
+    args = [str(filename.resolve()), "--uid", uid]
     cli(args)
 
-    with open(filename.absolute().name, 'r') as f:
+    with open(filename.resolve(), 'r') as f:
         jsonld = json.load(f)
 
     assert jsonld.get('@graph').get('uid') == uid
@@ -52,11 +54,11 @@ def test_scidatalib_cli_uid(tmp_path):
 def test_scidatalib_cli_indent(tmp_path):
     """Test for CLI to change indent (basic check)"""
     filename = tmp_path / "output.jsonld"
-    args = [filename.absolute().name, "--indent", "1"]
+    args = [str(filename.resolve()), "--indent", "1"]
 
     cli(args)
 
-    with open(filename.absolute().name, 'r') as f:
+    with open(filename.resolve(), 'r') as f:
         jsonld = json.load(f)
 
     assert '@context' in jsonld


### PR DESCRIPTION
Closes #47 

Work includes:
 - Fixing CLI tests for pytest's tmp_path - wasn't writing to a temporary directory and using `.absolute()` instead of `.resolve()` for pathlib calls
 - Added `io` module for file format read / write operations
 - Added `io.formats` to setup the translator design for different supported formats
 - Added `read` and `write` functions to `.io` to read in supported formats and write out to supported formats, respectively (currently none supported)