### PR TITLE
Fix for "startTime" (in camel case) -> "starttime"

### DIFF
--- a/scidatalib/scidata.py
+++ b/scidatalib/scidata.py
@@ -300,8 +300,8 @@ class SciData:
         SciDataObject.starttime('04-05-21 06:14:53')
         """
         if isinstance(stime, str):
-            self.meta['@graph']['startTime'] = stime
-        return self.meta['@graph']['startTime']
+            self.meta['@graph']['starttime'] = stime
+        return self.meta['@graph']['starttime']
 
     def permalink(self, link: str) -> dict:
         """

--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -105,6 +105,7 @@ def test_starttime(sd):
     now = datetime.now()
     timestr = now.strftime("%d/%m/%Y %H:%M:%S")
     assert sd.starttime(timestr) == timestr
+    assert sd.meta.get("@graph").get("starttime") == timestr
 
 
 def test_permalink(sd):


### PR DESCRIPTION
Re-opening #57 

From searching the SciData repo, looks like the correct field is "starttime".
https://github.com/stuchalk/scidata/search?q=startTime

We had the "startTime" camel cased, like the "generatedAt" field.

Work includes:

    Test to show it wasn't working as expected for the "starttime" field
    Fix to the "starttime" method
