### PR TITLE
Fix for the iterate function in SciData object

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,7 +2,6 @@
 from scidatalib.scidata import SciData
 import json
 import pandas as pd
-import numpy as np
 
 uid = 'example'
 example = SciData(uid)
@@ -193,7 +192,69 @@ pnt2 = {
 
 dps = [pnt1, pnt2]
 
-dps = [{"@id": "datapoint", "@type": "sdo:datapoint", "activity_id": 16464576, "assay": "CHEMBL3767769", "data": [{"type": "IC50", "@id": "datum", "@type": "sdo:exptdata", "value": {"relation": "=", "@id": "value", "@type": "sdo:value", "value": "19.000000000000000000000000000000", "units": "uM"}}, {"@id": "datum", "@type": "sdo:deriveddata", "value": {"standard_relation": "=", "@id": "value", "@type": "sdo:value", "standard_value": "19000.000000000000000000000000000000", "standard_units": "nM", "standard_type": "IC50", "pchembl_value": "4.72", "uo_units": "obo:UO_0000065", "qudt_units": "qudt:NanoMOL-PER-L"}}, {"@id": "datum", "@type": "sdo:None", "value": {"standard_flag": "1", "@id": "value", "@type": "sdo:value", "activity_id": "16464576"}}]}, {"@id": "datapoint", "annotation": "gb:P04524", "conditions": "Observation", "value": {"@id": "textvalue", "text": "The solution was clear, no reagent precipitation was observed.", "textype": "plain", "language": "en-us"}}]
+dp1_datum1 = {
+    "@id": "datum",
+    "@type": "sdo:exptdata",
+    "type": "IC50",
+    "value": {
+        "@id": "value",
+        "@type": "sdo:value",
+        "relation": "=",
+        "units": "uM",
+        "value": "19.000000000000000000000000000000"
+    }
+}
+
+dp1_datum2 = {
+    "@id": "datum",
+    "@type": "sdo:deriveddata",
+    "value": {
+        "standard_relation": "=",
+        "@id": "value",
+        "@type": "sdo:value",
+        "standard_value": "19000.000000000000000000000000000000",
+        "standard_units": "nM",
+        "standard_type": "IC50",
+        "pchembl_value": "4.72",
+        "uo_units": "obo:UO_0000065",
+        "qudt_units": "qudt:NanoMOL-PER-L"
+    }
+}
+
+dp1_datum3 = {
+    "@id": "datum",
+    "@type": "sdo:None",
+    "value": {
+        "standard_flag": "1",
+        "@id": "value",
+        "@type": "sdo:value",
+        "activity_id": "16464576"
+    }
+}
+
+dp1 = {
+    "@id": "datapoint",
+    "@type": "sdo:datapoint",
+    "activity_id": 16464576,
+    "assay": "CHEMBL3767769",
+    "data": [dp1_datum1, dp1_datum2, dp1_datum3]
+}
+
+# Input datapoint 2
+dp2 = {
+    "@id": "datapoint",
+    "annotation": "gb:P04524",
+    "conditions": "Observation",
+    "value": {
+        "@id": "textvalue",
+        "text":
+            "The solution was clear, no reagent precipitation was observed.",
+        "textype": "plain",
+        "language": "en-us"
+    }
+}
+
+dps = [dp1, dp2]
 
 example.datapoint(dps)
 
@@ -218,10 +279,10 @@ dataser1 = {
     'values_numpy_array': str(ser1_numpy_array),
     'values_numpy_list': str(ser1_numpy_list),
     'values_numpy_json': str(ser1_numpy_json)}
-for k,v in ser1_dict.items():
-    dataser1.update({str(k):str(v)})
-for k,v in ser1_dict_str.items():
-    dataser1.update({str('str_'+k):v})
+for k, v in ser1_dict.items():
+    dataser1.update({str(k): str(v)})
+for k, v in ser1_dict_str.items():
+    dataser1.update({str('str_'+k): v})
 
 ser2_input = {'colA': [10, 20, 30]}
 ser2_dataframe = pd.DataFrame(ser2_input)
@@ -244,10 +305,10 @@ dataser2 = {
     'values_numpy_array': str(ser2_numpy_array),
     'values_numpy_list': str(ser2_numpy_list),
     'values_numpy_json': str(ser2_numpy_json)}
-for k,v in ser2_dict.items():
-    dataser2.update({str(k):str(v)})
-for k,v in ser2_dict_str.items():
-    dataser2.update({str('str_'+k):v})
+for k, v in ser2_dict.items():
+    dataser2.update({str(k): str(v)})
+for k, v in ser2_dict_str.items():
+    dataser2.update({str('str_'+k): v})
 
 example.dataseries([dataser1, dataser2])
 

--- a/scidatalib/io/rruff.py
+++ b/scidatalib/io/rruff.py
@@ -135,7 +135,7 @@ def _read_get_facets_section(rruff_dict: dict) -> dict:
     facets = []
     material = {
         "@id": "material",
-        "@type": ["sdo:facet", "sdo:material"],
+        "@type": "sdo:material",
         "name": rruff_dict.get("names", ""),
         "materialType": rruff_dict.get("ideal chemistry", ""),
     }

--- a/tests/io/test_rruff.py
+++ b/tests/io/test_rruff.py
@@ -73,7 +73,7 @@ def test_read_rruff(raman_soddyite_file):
     assert len(system["facets"]) == 1
     facet = system["facets"][0]
     assert facet["@id"] == "material/1/"
-    assert len(facet["@type"]) == 2
+    assert facet["@type"] == "sdo:material"
     assert facet["materialType"] == "(UO_2_)_2_SiO_4_&#183;2H_2_O"
     assert facet["name"] == "Soddyite"
 

--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -260,10 +260,12 @@ def test_datapoint_nested(sd):
     # Input datapoint 2
     dp2 = {
         "@id": "datapoint",
+        "@type": "sdo:datapoint",
         "annotation": "gb:P04524",
         "conditions": "Observation",
         "value": {
             "@id": "textvalue",
+            "@type": "sdo:textvalue",
             "text":
                 "The solution was clear, no reagent precipitation was observed.", # noqa
             "textype": "plain",
@@ -291,7 +293,7 @@ def test_datapoint_nested(sd):
     out_dp2 = copy.deepcopy(dp2)
 
     out_dp2["@id"] = "datapoint/2/"
-    out_dp1_datum3["@id"] = "datapoint/2/textvalue/1/"
+    out_dp2["value"]["@id"] = "datapoint/2/textvalue/1/"
 
     assert sd.datapoint([dp1, dp2]) == [out_dp1, out_dp2]
 

--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -1,4 +1,5 @@
 """pytest test class for scidata.py"""
+import copy
 from scidatalib.scidata import SciData
 from datetime import datetime
 import pytest
@@ -204,120 +205,94 @@ def test_datapoint(sd):
 
 
 def test_datapoint_nested(sd):
+    """Test multiple, nested datum in datapoints for correct enumeration"""
     sd.namespaces({'gb': 'https://goldbook.iupac.org/terms/view/'})
-    dps = [
-        {
-            "@id": "datapoint",
-            "@type": "sdo:datapoint",
-            "activity_id": 16464576,
-            "assay": "CHEMBL3767769",
-            "data": [
-                {
-                    "type": "IC50",
-                    "@id": "datum",
-                    "@type": "sdo:exptdata",
-                    "value": {
-                        "relation": "=",
-                        "@id": "value",
-                        "@type": "sdo:value",
-                        "value": "19.000000000000000000000000000000",
-                        "units": "uM"
-                    }
-                }, {
-                    "@id": "datum",
-                    "@type": "sdo:deriveddata",
-                    "value": {
-                        "standard_relation": "=",
-                        "@id": "value",
-                        "@type": "sdo:value",
-                        "standard_value": "19000.000000000000000000000000000000",
-                        "standard_units": "nM",
-                        "standard_type": "IC50",
-                        "pchembl_value": "4.72",
-                        "uo_units": "obo:UO_0000065",
-                        "qudt_units": "qudt:NanoMOL-PER-L"
-                    }
-                }, {
-                    "@id": "datum",
-                    "@type": "sdo:None",
-                    "value": {
-                        "standard_flag": "1",
-                        "@id": "value",
-                        "@type": "sdo:value",
-                        "activity_id": "16464576"
-                    }
-                }
-            ]
-        }, {
-            "@id": "datapoint",
-            "annotation": "gb:P04524",
-            "conditions": "Observation",
-            "value": {
-                "@id": "textvalue",
-                "text": "The solution was clear, no reagent precipitation was observed.",
-                "textype": "plain",
-                "language": "en-us"
-            }
+
+    # Input datapoint 1
+    dp1_datum1 = {
+        "@id": "datum",
+        "@type": "sdo:exptdata",
+        "type": "IC50",
+        "value": {
+            "@id": "value",
+            "@type": "sdo:value",
+            "relation": "=",
+            "units": "uM",
+            "value": "19.000000000000000000000000000000"
         }
-    ]
-    out = [
-        {
-	        "@id": "datapoint/1/",
-	        "@type": "sdo:datapoint",
-	        "activity_id": 16464576,
-	        "assay": "CHEMBL3767769",
-	        "data": [
-                {
-		            "@id": "datapoint/1/datum/1/",
-		            "@type": "sdo:exptdata",
-		            "type": "IC50",
-		            "value": {
-			            "@id": "datapoint/1/datum/1/value/1/",
-			            "@type": "sdo:value",
-			            "relation": "=",
-			            "units": "uM",
-			            "value": "19.000000000000000000000000000000"
-		            }
-	            }, {
-		            "@id": "datapoint/1/datum/2/",
-		            "@type": "sdo:deriveddata",
-		            "value": {
-			            "@id": "datapoint/1/datum/2/value/1/",
-			            "@type": "sdo:value",
-			            "pchembl_value": "4.72",
-			            "qudt_units": "qudt:NanoMOL-PER-L",
-			            "standard_relation": "=",
-			            "standard_type": "IC50",
-			            "standard_units": "nM",
-			            "standard_value": "19000.000000000000000000000000000000",
-			            "uo_units": "obo:UO_0000065"
-		            }
-	            }, {
-		            "@id": "datapoint/1/datum/3",
-		            "@type": "sdo:None",
-		            "value": {
-			            "@id": "datapoint/1/datum/3/value/1/",
-			            "@type": "sdo:value",
-			            "activity_id": "16464576",
-			            "standard_flag": "1"
-		            }
-	            }
-            ]
-        }, {
-	        "@id": "datapoint/2/",
-	        "@type": "sdo:datapoint",
-            "annotation": "gb:P04524",
-	        "conditions": "Observation",
-	        "value": {
-		        "@id": "datapoint/2/textvalue/1/",
-		        "@type": "sdo:textvalue",
-		        "language": "en-us",
-		        "text": "The solution was clear, no reagent precipitation was observed.",
-		        "textype": "plain"
-	        }
+    }
+
+    dp1_datum2 = {
+        "@id": "datum",
+        "@type": "sdo:deriveddata",
+        "value": {
+            "standard_relation": "=",
+            "@id": "value",
+            "@type": "sdo:value",
+            "standard_value": "19000.000000000000000000000000000000",
+            "standard_units": "nM",
+            "standard_type": "IC50",
+            "pchembl_value": "4.72",
+            "uo_units": "obo:UO_0000065",
+            "qudt_units": "qudt:NanoMOL-PER-L"
         }
-    ]
-    assert sd.datapoint(dps) == out
+    }
+
+    dp1_datum3 = {
+        "@id": "datum",
+        "@type": "sdo:None",
+        "value": {
+            "standard_flag": "1",
+            "@id": "value",
+            "@type": "sdo:value",
+            "activity_id": "16464576"
+        }
+    }
+
+    dp1 = {
+        "@id": "datapoint",
+        "@type": "sdo:datapoint",
+        "activity_id": 16464576,
+        "assay": "CHEMBL3767769",
+        "data": [dp1_datum1, dp1_datum2, dp1_datum3]
+    }
+
+    # Input datapoint 2
+    dp2 = {
+        "@id": "datapoint",
+        "annotation": "gb:P04524",
+        "conditions": "Observation",
+        "value": {
+            "@id": "textvalue",
+            "text": "The solution was clear, no reagent precipitation was observed.",
+            "textype": "plain",
+            "language": "en-us"
+        }
+    }
+
+    # Create target output datapoints
+    out_dp1 = copy.deepcopy(dp1)
+
+    out_dp1["@id"] = "datapoint/1/"
+
+    out_dp1_datum1 = out_dp1["data"][0]
+    out_dp1_datum1["@id"] = "datapoint/1/datum/1/"
+    out_dp1_datum1["value"]["@id"] = "datapoint/1/datum/1/value/1/"
+
+    out_dp1_datum2 = out_dp1["data"][1]
+    out_dp1_datum2["@id"] = "datapoint/1/datum/2/"
+    out_dp1_datum2["value"]["@id"] = "datapoint/1/datum/2/value/1/"
+
+    out_dp1_datum3 = out_dp1["data"][2]
+    out_dp1_datum3["@id"] = "datapoint/1/datum/3/"
+    out_dp1_datum3["value"]["@id"] = "datapoint/1/datum/3/value/1/"
+
+    out_dp2 = copy.deepcopy(dp2)
+
+    out_dp2["@id"] = "datapoint/2/"
+    out_dp1_datum3["@id"] = "datapoint/2/textvalue/1/"
+
+    assert sd.datapoint([dp1, dp2]) == [out_dp1, out_dp2]
 
 
 def test_datagroup_with_datapoints(sd):

--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -264,7 +264,8 @@ def test_datapoint_nested(sd):
         "conditions": "Observation",
         "value": {
             "@id": "textvalue",
-            "text": "The solution was clear, no reagent precipitation was observed.",
+            "text":
+                "The solution was clear, no reagent precipitation was observed.", # noqa
             "textype": "plain",
             "language": "en-us"
         }

--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -203,6 +203,123 @@ def test_datapoint(sd):
     assert sd.datapoint([pnt]) == [out]
 
 
+def test_datapoint_nested(sd):
+    sd.namespaces({'gb': 'https://goldbook.iupac.org/terms/view/'})
+    dps = [
+        {
+            "@id": "datapoint",
+            "@type": "sdo:datapoint",
+            "activity_id": 16464576,
+            "assay": "CHEMBL3767769",
+            "data": [
+                {
+                    "type": "IC50",
+                    "@id": "datum",
+                    "@type": "sdo:exptdata",
+                    "value": {
+                        "relation": "=",
+                        "@id": "value",
+                        "@type": "sdo:value",
+                        "value": "19.000000000000000000000000000000",
+                        "units": "uM"
+                    }
+                }, {
+                    "@id": "datum",
+                    "@type": "sdo:deriveddata",
+                    "value": {
+                        "standard_relation": "=",
+                        "@id": "value",
+                        "@type": "sdo:value",
+                        "standard_value": "19000.000000000000000000000000000000",
+                        "standard_units": "nM",
+                        "standard_type": "IC50",
+                        "pchembl_value": "4.72",
+                        "uo_units": "obo:UO_0000065",
+                        "qudt_units": "qudt:NanoMOL-PER-L"
+                    }
+                }, {
+                    "@id": "datum",
+                    "@type": "sdo:None",
+                    "value": {
+                        "standard_flag": "1",
+                        "@id": "value",
+                        "@type": "sdo:value",
+                        "activity_id": "16464576"
+                    }
+                }
+            ]
+        }, {
+            "@id": "datapoint",
+            "annotation": "gb:P04524",
+            "conditions": "Observation",
+            "value": {
+                "@id": "textvalue",
+                "text": "The solution was clear, no reagent precipitation was observed.",
+                "textype": "plain",
+                "language": "en-us"
+            }
+        }
+    ]
+    out = [
+        {
+	        "@id": "datapoint/1/",
+	        "@type": "sdo:datapoint",
+	        "activity_id": 16464576,
+	        "assay": "CHEMBL3767769",
+	        "data": [
+                {
+		            "@id": "datapoint/1/datum/1/",
+		            "@type": "sdo:exptdata",
+		            "type": "IC50",
+		            "value": {
+			            "@id": "datapoint/1/datum/1/value/1/",
+			            "@type": "sdo:value",
+			            "relation": "=",
+			            "units": "uM",
+			            "value": "19.000000000000000000000000000000"
+		            }
+	            }, {
+		            "@id": "datapoint/1/datum/2/",
+		            "@type": "sdo:deriveddata",
+		            "value": {
+			            "@id": "datapoint/1/datum/2/value/1/",
+			            "@type": "sdo:value",
+			            "pchembl_value": "4.72",
+			            "qudt_units": "qudt:NanoMOL-PER-L",
+			            "standard_relation": "=",
+			            "standard_type": "IC50",
+			            "standard_units": "nM",
+			            "standard_value": "19000.000000000000000000000000000000",
+			            "uo_units": "obo:UO_0000065"
+		            }
+	            }, {
+		            "@id": "datapoint/1/datum/3",
+		            "@type": "sdo:None",
+		            "value": {
+			            "@id": "datapoint/1/datum/3/value/1/",
+			            "@type": "sdo:value",
+			            "activity_id": "16464576",
+			            "standard_flag": "1"
+		            }
+	            }
+            ]
+        }, {
+	        "@id": "datapoint/2/",
+	        "@type": "sdo:datapoint",
+            "annotation": "gb:P04524",
+	        "conditions": "Observation",
+	        "value": {
+		        "@id": "datapoint/2/textvalue/1/",
+		        "@type": "sdo:textvalue",
+		        "language": "en-us",
+		        "text": "The solution was clear, no reagent precipitation was observed.",
+		        "textype": "plain"
+	        }
+        }
+    ]
+    assert sd.datapoint(dps) == out
+
+
 def test_datagroup_with_datapoints(sd):
     sd.namespaces(
         {


### PR DESCRIPTION
Work includes:
 - Adds a test for nested objects via using datum in datapoints
 - Adds this as an example to the example python script
 - Fix for a recursion error in `SciData.__iterate_function`. Mainly fixed:
   -  Making sure the category count was incremented properly
   - This category count was used in constructing the `@id` entry
   - Upon "leaving", the function drops the "leaf" / latest level of nesting so that it doesn't include it in the next `@id` AND resetting the counter for the category back to 0 such that the counter doesn't use the previous max value for a separate nested object