### PR TITLE
Adds dataseries to rruff reader and writer

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -48,6 +48,17 @@ jobs:
             pip install coverage
             bash <(curl -s https://codecov.io/bash)
 
+      - name: Build Python package and Upload to TestPyPi
+        shell: bash -l {0}
+        if: startsWith( github.ref, 'refs/tags/v') && matrix.python-version == env.PYTHON_MAIN_VERSION
+        env:
+          TEST_PYPI_TOKEN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: |
+          poetry update
+          poetry build
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry publish -r testpypi --username "__token__" --password $TEST_PYPI_TOKEN_PASSWORD
+
       - name: Build Python package and Upload to PyPi
         shell: bash -l {0}
         if: startsWith( github.ref, 'refs/tags/v') && matrix.python-version == env.PYTHON_MAIN_VERSION
@@ -57,14 +68,3 @@ jobs:
           poetry update
           poetry build
           poetry publish --username "__token__" --password $PYPI_TOKEN_PASSWORD
-
-      - name: Build Python package and Upload to TestPyPi
-        shell: bash -l {0}
-        if: ${{ matrix.python-version == env.PYTHON_MAIN_VERSION }}
-        env:
-          TEST_PYPI_TOKEN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-        run: |
-          poetry update
-          poetry build
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry publish -r testpypi --username "__token__" --password $TEST_PYPI_TOKEN_PASSWORD

--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,161 @@ fabric.properties
 # any other files in the .idea folder
 .idea/*
 
-# coverage report
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/scidatalib/io/rruff.py
+++ b/scidatalib/io/rruff.py
@@ -220,8 +220,8 @@ def _read_translate_rruff_to_scidata(rruff_dict: dict) -> dict:
     datagroup = jcamp._read_get_datagroup_subsection(rruff_dict)
     scidata.datagroup([datagroup])
 
-    # TODO: add the dataseries
-    #   Issue: https://github.com/ChalkLab/SciDataLib/issues/43
+    dataseries = jcamp._read_get_dataseries_subsection(rruff_dict)
+    scidata.dataseries(dataseries)
 
     return scidata
 

--- a/tests/io/test_jcamp.py
+++ b/tests/io/test_jcamp.py
@@ -597,21 +597,21 @@ def test_read_get_facets_section():
 
 
 def test_read_get_dataseries_subsection():
-    x = np.arange(0., 10., 0.1)
-    y = np.random.random(len(x))
+    xset = [str(x) for x in np.arange(0., 10., 0.1)]
+    yset = [str(y) for y in np.random.random(len(xset))]
     jcamp_dict = {
-        "x": x,
-        "y": y,
+        "x": xset,
+        "y": yset,
         "xunits": "1/CM",
     }
     result = jcamp._read_get_dataseries_subsection(jcamp_dict)
 
-    result_x = result[0]["parameter"]["valuearray"]["numberarray"]
-    result_y = result[1]["parameter"]["valuearray"]["numberarray"]
-    result_xunit = result[0]["parameter"]["valuearray"]["unitref"]
+    result_x = result[0]["parameter"][0]["dataarray"]
+    result_y = result[0]["parameter"][1]["dataarray"]
+    result_xunit = result[0]["parameter"][0]["unitref"]
 
-    assert list(x) == list(result_x)
-    assert list(y) == list(result_y)
+    assert list(xset) == list(result_x)
+    assert list(yset) == list(result_y)
     assert "qudt:PER-CentiM" == result_xunit
 
 
@@ -697,6 +697,10 @@ def test_read_jcamp_function(raman_tannic_acid_file):
     scidata_obj = jcamp.read_jcamp(raman_tannic_acid_file)
     assert type(scidata_obj) == SciData
 
+    dataset = scidata_obj.output.get("@graph").get("scidata").get("dataset")
+    dataseries = dataset.get("dataseries")[0]
+    assert dataseries.get("@id") == "dataseries/1/"
+
 
 def test_read_jcamp(raman_tannic_acid_file):
     scidata_obj = read(raman_tannic_acid_file, ioformat="jcamp")
@@ -729,7 +733,6 @@ def test_write_jcamp_function(tmp_path, raman_tannic_acid_file):
         assert result_list == target_list
 
 
-@pytest.mark.skip(reason="Missing dataseries for comparison")
 def test_write_jcamp(tmp_path, raman_tannic_acid_file):
     scidata = jcamp.read_jcamp(raman_tannic_acid_file.resolve())
     jcamp_dir = tmp_path / "jcamp"

--- a/tests/io/test_rruff.py
+++ b/tests/io/test_rruff.py
@@ -78,7 +78,6 @@ def test_read_rruff(raman_soddyite_file):
     assert facet["name"] == "Soddyite"
 
 
-@pytest.mark.skip(reason="Missing dataseries for comparison")
 def test_write_rruff(tmp_path, raman_soddyite_file):
     scidata = rruff.read_rruff(raman_soddyite_file.absolute())
     rruff_dir = tmp_path / "rruff"

--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -456,13 +456,15 @@ def test_dataseries(sd):
                 "@id": "parameter",
                 "quantity": "Raman Shift",
                 "property": "Raman Shift",
-                "units": "1/cm",
+                "units":    "1/cm",
+                "axis":     "x-axis",
                 "datatype": "decimal",
                 "dataarray": series_x
             }, {
                 "@id": "parameter",
                 "quantity": "intensity",
                 "property": "intensity",
+                "axis":     "y-axis",
                 "datatype": "decimal",
                 "dataarray": series_y
             }
@@ -481,6 +483,7 @@ def test_dataseries(sd):
             "quantity": "Raman Shift",
             "property": "Raman Shift",
             "units": "1/cm",
+            "axis":     "x-axis",
             "datatype": "decimal",
             "dataarray": [
               "107.9252",
@@ -499,6 +502,7 @@ def test_dataseries(sd):
             "@type": "sdo:parameter",
             "quantity": "intensity",
             "property": "intensity",
+            "axis":     "y-axis",
             "datatype": "decimal",
             "dataarray": [
               "831.4121",
@@ -518,6 +522,9 @@ def test_dataseries(sd):
 
     result = sd.dataseries([dataseries_1])
     assert out == result
+
+    output_result = sd.output.get("@graph").get("scidata").get("dataset").get("dataseries")
+    assert out == output_result
 
 
 @pytest.mark.skip(reason="Need to figure out the output format")

--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -423,6 +423,103 @@ def test_datapoint_nested(sd):
     assert sd.datapoint([dp1, dp2]) == [out_dp1, out_dp2]
 
 
+def test_dataseries(sd):
+    series_x = [
+        '107.9252',
+        '108.4073',
+        '108.8894',
+        '109.3715',
+        '109.8536',
+        '110.3358',
+        '110.8179',
+        '111.3000',
+        '111.7821'
+    ]
+
+    series_y = [
+        '831.4121',
+        '833.1594',
+        '839.9602',
+        '848.9200',
+        '855.5815',
+        '860.6728',
+        '862.4740',
+        '859.3690',
+        '851.6688'
+    ]
+
+    dataseries_1 = {
+        "@id": "dataseries",
+        "label": "Raman Spectroscopy",
+        "parameter": [
+            {
+                "@id": "parameter",
+                "quantity": "Raman Shift",
+                "property": "Raman Shift",
+                "units": "1/cm",
+                "datatype": "decimal",
+                "dataarray": series_x
+            }, {
+                "@id": "parameter",
+                "quantity": "intensity",
+                "property": "intensity",
+                "datatype": "decimal",
+                "dataarray": series_y
+            }
+        ]
+    }
+
+    out = [
+      {
+        "@id": "dataseries/1/",
+        "@type": "sdo:dataseries",
+        "label": "Raman Spectroscopy",
+        "parameter": [
+          {
+            "@id": "dataseries/1/parameter/1/",
+            "@type": "sdo:parameter",
+            "quantity": "Raman Shift",
+            "property": "Raman Shift",
+            "units": "1/cm",
+            "datatype": "decimal",
+            "dataarray": [
+              "107.9252",
+              "108.4073",
+              "108.8894",
+              "109.3715",
+              "109.8536",
+              "110.3358",
+              "110.8179",
+              "111.3000",
+              "111.7821"
+            ]
+          },
+          {
+            "@id": "dataseries/1/parameter/2/",
+            "@type": "sdo:parameter",
+            "quantity": "intensity",
+            "property": "intensity",
+            "datatype": "decimal",
+            "dataarray": [
+              "831.4121",
+              "833.1594",
+              "839.9602",
+              "848.9200",
+              "855.5815",
+              "860.6728",
+              "862.4740",
+              "859.3690",
+              "851.6688"
+            ]
+          }
+        ]
+      }
+    ]
+
+    result = sd.dataseries([dataseries_1])
+    assert out == result
+
+
 @pytest.mark.skip(reason="Need to figure out the output format")
 def test_datagroup_with_datapoints(sd):
     sd.namespaces(

--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -423,99 +423,106 @@ def test_datapoint_nested(sd):
     assert sd.datapoint([dp1, dp2]) == [out_dp1, out_dp2]
 
 
-# def test_datagroup_with_datapoints(sd):
-#     sd.namespaces(
-#         {
-#             'gb': 'https://goldbook.iupac.org/terms/view/',
-#             'qudt': 'http://qudt.org/vocab/unit/'
-#         }
-#     )
-#     atid = 'numericvalue'
-#     val1 = {'@id': atid, 'number': 0.99913, 'unitref': 'qudt:GM-PER-MilliL'}
-#     val2 = {'@id': atid, 'number': 0.99823, 'unitref': 'qudt:GM-PER-MilliL'}
-#     val3 = {'@id': atid, 'number': 0.99707, 'unitref': 'qudt:GM-PER-MilliL'}
-#     pnt1 = {
-#         '@id': 'datapoint',
-#         'quantity': 'gb:D01590',
-#         'conditions': 'condition/1/',
-#         'value': val1
-#     }
-#     pnt2 = {
-#         '@id': 'datapoint',
-#         'quantity': 'gb:D01590',
-#         'conditions': 'condition/2/',
-#         'value': val2
-#     }
-#     pnt3 = {
-#         '@id': 'datapoint',
-#         'quantity': 'gb:D01590',
-#         'conditions': 'condition/3/',
-#         'value': val3
-#     }
-#     grp = {
-#         '@id': 'datagroup',
-#         'source': 'chemicalsystem/1/',
-#         'datapoints': [pnt1, pnt2, pnt3]
-#     }
-#     out = {
-#         "@id": "datagroup/1/",
-#         "@type": "sdo:datagroup",
-#         "source": "chemicalsystem/1/",
-#         "datapoints": [
-#             "datapoint/1/",
-#             "datapoint/2/",
-#             "datapoint/3/"
-#         ]
-#     }
-#     assert sd.datagroup([grp]) == [out]
-#
-#
-# def test_datagroup_with_attributes(sd):
-#     sd.namespaces(
-#         {
-#             'gb': 'https://goldbook.iupac.org/terms/view/',
-#             'qudt': 'http://qudt.org/vocab/unit/'
-#         }
-#     )
-#
-#     # Create an X data vector
-#     datax = [0.1 * i for i in range(10)]
-#
-#     # Setup attributes of the X data
-#     atid = 'numericvalue'
-#     val1 = {'@id': atid, 'number': min(datax), 'unitref': 'qudt:PER-CentiM'}
-#     val2 = {'@id': atid, 'number': max(datax), 'unitref': 'qudt:PER-CentiM'}
-#     val3 = {'@id': atid, 'number': len(datax), 'unitref': 'qudt:PER-CentiM'}
-#     pnt1 = {
-#         '@id': 'attribute',
-#         'quantity': 'gb:W06659',
-#         'value': val1
-#     }
-#     pnt2 = {
-#         '@id': 'attribute',
-#         'quantity': 'gb:W06659',
-#         'value': val2
-#     }
-#     pnt3 = {
-#         '@id': 'attribute',
-#         'quantity': 'gb:W06659',
-#         'value': val3
-#     }
-#     grp = {
-#         '@id': 'datagroup',
-#         'attribute': [pnt1, pnt2, pnt3]
-#     }
-#     out = {
-#         "@id": "datagroup/1/",
-#         "@type": "sdo:datagroup",
-#         "attribute": [
-#             "attribute/1/",
-#             "attribute/2/",
-#             "attribute/3/"
-#         ]
-#     }
-#     result = sd.datagroup([grp])
-#     assert result == [out]
+@pytest.mark.skip(reason="Need to figure out the output format")
+def test_datagroup_with_datapoints(sd):
+    sd.namespaces(
+        {
+            'gb': 'https://goldbook.iupac.org/terms/view/',
+            'qudt': 'http://qudt.org/vocab/unit/'
+        }
+    )
+    atid = 'numericvalue'
+    val1 = {'@id': atid, 'number': 0.99913, 'unitref': 'qudt:GM-PER-MilliL'}
+    val2 = {'@id': atid, 'number': 0.99823, 'unitref': 'qudt:GM-PER-MilliL'}
+    val3 = {'@id': atid, 'number': 0.99707, 'unitref': 'qudt:GM-PER-MilliL'}
+    pnt1 = {
+        '@id': 'datapoint',
+        'quantity': 'gb:D01590',
+        'conditions': 'condition/1/',
+        'value': val1
+    }
+    pnt2 = {
+        '@id': 'datapoint',
+        'quantity': 'gb:D01590',
+        'conditions': 'condition/2/',
+        'value': val2
+    }
+    pnt3 = {
+        '@id': 'datapoint',
+        'quantity': 'gb:D01590',
+        'conditions': 'condition/3/',
+        'value': val3
+    }
+    grp = {
+        '@id': 'datagroup',
+        'source': 'chemicalsystem/1/',
+        'datapoints': [pnt1, pnt2, pnt3]
+    }
+    out = {
+        "@id": "datagroup/1/",
+        "@type": "sdo:datagroup",
+        "source": "chemicalsystem/1/",
+        "datapoints": [
+            "datapoint/1/",
+            "datapoint/2/",
+            "datapoint/3/"
+        ]
+    }
+
+    result = sd.datagroup([grp])
+
+    assert result == [out]
+
+
+@pytest.mark.skip(reason="Need to figure out the output format")
+def test_datagroup_with_attributes(sd):
+    sd.namespaces(
+        {
+            'gb': 'https://goldbook.iupac.org/terms/view/',
+            'qudt': 'http://qudt.org/vocab/unit/'
+        }
+    )
+
+    # Create an X data vector
+    datax = [0.1 * i for i in range(10)]
+
+    # Setup attributes of the X data
+    atid = 'numericvalue'
+    val1 = {'@id': atid, 'number': min(datax), 'unitref': 'qudt:PER-CentiM'}
+    val2 = {'@id': atid, 'number': max(datax), 'unitref': 'qudt:PER-CentiM'}
+    val3 = {'@id': atid, 'number': len(datax), 'unitref': 'qudt:PER-CentiM'}
+    pnt1 = {
+        '@id': 'attribute',
+        'quantity': 'gb:W06659',
+        'value': val1
+    }
+    pnt2 = {
+        '@id': 'attribute',
+        'quantity': 'gb:W06659',
+        'value': val2
+    }
+    pnt3 = {
+        '@id': 'attribute',
+        'quantity': 'gb:W06659',
+        'value': val3
+    }
+    grp = {
+        '@id': 'datagroup',
+        'attribute': [pnt1, pnt2, pnt3]
+    }
+    out = {
+        "@id": "datagroup/1/",
+        "@type": "sdo:datagroup",
+        "attribute": [
+            "attribute/1/",
+            "attribute/2/",
+            "attribute/3/"
+        ]
+    }
+
+    result = sd.datagroup([grp])
+
+    assert result == [out]
 
 
 def test_source(sd):

--- a/tests/test_scidata.py
+++ b/tests/test_scidata.py
@@ -523,7 +523,8 @@ def test_dataseries(sd):
     result = sd.dataseries([dataseries_1])
     assert out == result
 
-    output_result = sd.output.get("@graph").get("scidata").get("dataset").get("dataseries")
+    graph = sd.output.get("@graph")
+    output_result = graph.get("scidata").get("dataset").get("dataseries")
     assert out == output_result
 
 


### PR DESCRIPTION
Closes #50, #51 

Work  includes:
  - Re-enabling the RRUFF read / write test
  - Adds the dataseries to the SciData object created by `scidata.io.rruff` module


Draft because this relies on another draft PR branch: https://github.com/ChalkLab/SciDataLib/pull/69