### PR TITLE
Split release yamls

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - '*'
-    tags:
-      - '*'
 
 jobs:
   build:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - '*'
     tags:
-      - 'v*'
+      - '*'
 
 jobs:
   build:
@@ -47,24 +47,3 @@ jobs:
             poetry run pytest --cov=scidatalib --cov-report=term-missing tests/
             pip install coverage
             bash <(curl -s https://codecov.io/bash)
-
-      - name: Build Python package and Upload to TestPyPi
-        shell: bash -l {0}
-        if: startsWith( github.ref, 'refs/tags/v') && matrix.python-version == env.PYTHON_MAIN_VERSION
-        env:
-          TEST_PYPI_TOKEN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-        run: |
-          poetry update
-          poetry build
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry publish -r testpypi --username "__token__" --password $TEST_PYPI_TOKEN_PASSWORD
-
-      - name: Build Python package and Upload to PyPi
-        shell: bash -l {0}
-        if: startsWith( github.ref, 'refs/tags/v') && matrix.python-version == env.PYTHON_MAIN_VERSION
-        env:
-          PYPI_TOKEN_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          poetry update
-          poetry build
-          poetry publish --username "__token__" --password $PYPI_TOKEN_PASSWORD

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -5,8 +5,8 @@ env:
 
 on:
   push:
-    branches: master
-    tags: releases/v[0-9]+.[0-9]+.[0-9]+-*
+    branches: 'master'
+    tags: 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   build:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,40 @@
+name: Release to PyPi 
+
+env:
+  POETRY_VERSION: 1.1.4
+
+on:
+  push:
+    branches: master
+    tags: releases/v[0-9]+.[0-9]+.[0-9]+-*
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+            python -m pip install poetry==${{ env.POETRY_VERSION }}
+            poetry install
+
+      - name: Build Python package and Upload to PyPi
+        shell: bash -l {0}
+        if: startsWith( github.ref, 'refs/tags/v')
+        env:
+          PYPI_TOKEN_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          poetry update
+          poetry build
+          poetry publish --username "__token__" --password $PYPI_TOKEN_PASSWORD

--- a/.github/workflows/test-releases.yml
+++ b/.github/workflows/test-releases.yml
@@ -5,7 +5,7 @@ env:
 
 on:
   push:
-    branches: master
+    branches: split-release-yamls
     tags: releases/test-v[0-9]+.[0-9]+.[0-9]+-*
 
 jobs:

--- a/.github/workflows/test-releases.yml
+++ b/.github/workflows/test-releases.yml
@@ -1,0 +1,41 @@
+name: Release to TestPyPi 
+
+env:
+  POETRY_VERSION: 1.1.4
+
+on:
+  push:
+    branches: master
+    tags: releases/test-v[0-9]+.[0-9]+.[0-9]+-*
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+            python -m pip install poetry==${{ env.POETRY_VERSION }}
+            poetry install
+
+      - name: Build Python package and Upload to TestPyPi
+        shell: bash -l {0}
+        if: startsWith( github.ref, 'refs/tags/test-')
+        env:
+          TEST_PYPI_TOKEN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: |
+          poetry update
+          poetry build
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry publish -r testpypi --username "__token__" --password $TEST_PYPI_TOKEN_PASSWORD

--- a/.github/workflows/test-releases.yml
+++ b/.github/workflows/test-releases.yml
@@ -5,8 +5,8 @@ env:
 
 on:
   push:
-    branches: split-release-yamls
-    tags: releases/test-v[0-9]+.[0-9]+.[0-9]+-*
+    branches: 'split-release-yamls'
+    tags: 'test-v[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   build:

--- a/.github/workflows/test-releases.yml
+++ b/.github/workflows/test-releases.yml
@@ -5,7 +5,7 @@ env:
 
 on:
   push:
-    branches: 'split-release-yamls'
+    branches: 'master'
     tags: 'test-v[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,5 @@ cython_debug/
 #.idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+
+*.swp

--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ Get code coverage reporting using the [pytest-cov](https://pytest-cov.readthedoc
 poetry run pytest --cov=scidatalib --cov-report=term-missing tests/
 ```
 
+# Release
+
+For developers, please see [Release Workflow](https://github.com/ChalkLab/SciDataLib/wiki/Release-Workflow).
+
 # Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SciDataLib"
-version = "v0.2.6-alpha.1"
+version = "v0.2.5"
 description = "Python library for development of SciData JSON-LD files"
 authors = [
     "Stuart Chalk <schalk@unf.edu>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SciDataLib"
-version = "v0.2.5"
+version = "0.2.5"
 description = "Python library for development of SciData JSON-LD files"
 authors = [
     "Stuart Chalk <schalk@unf.edu>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SciDataLib"
-version = "0.2.5"
+version = "test-v0.2.6-alpha.1"
 description = "Python library for development of SciData JSON-LD files"
 authors = [
     "Stuart Chalk <schalk@unf.edu>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SciDataLib"
-version = "test-v0.2.6-alpha.1"
+version = "v0.2.6-alpha.1"
 description = "Python library for development of SciData JSON-LD files"
 authors = [
     "Stuart Chalk <schalk@unf.edu>",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,21 +1,2 @@
-[metadata]
-# replace with your username:
-name = SciDataLib
-version = 0.2.5
-url = https://github.com/ChalkLab/SciDataLib
-author = 'Dylan Johnson, Marshall McDonnell, Stuart Chalk'
-author_email = 'n01448636@unf.edu, mcdonnellmt@ornl.gov, schalk@unf.edu'
-classifiers =
-    Programming Language :: Python :: 3
-    License :: OSI Approved :: MIT License
-    Operating System :: OS Independent
-description = Python library for creation of SciData JSON-LD files
-long_description = file: README.md
-long_description_content_type = text/markdown
-
-[options]
-python_requires = >=3.6
-
 [flake8]
  # add options
-


### PR DESCRIPTION
This mainly splits up the test and primary releases to TestPyPi and PyPi, respectively.

Work includes:
  - Creates a separate `.github/workflows/releases.yml` for the primary PyPi release setup. Will run on `master` branch for tags that match `vX.Y.Z-*` pattern for semantic versioning (examples: `v0.2.6`, `v0.2.7-alpha.4`, etc.)
  - Creates a separate `.github/workflows/test-releases.yml` for the test PyPi release setup. Will run on `master branch for tags that match `test-vX.Y.Z-*` pattern.
  - Normal CI ops (build, test, lint, coverage) now run on all branches w/o any tag filtering
  - Adds [link in README](https://github.com/ChalkLab/SciDataLib/tree/split-release-yamls#release) to the new [Release Workflow wiki page](https://github.com/ChalkLab/SciDataLib/wiki/Release-Workflow) to help explain our release process to development team
  - Removes re-redundant info from `setup.cfg` that was also in the `pyproject.toml`