### PR TITLE
Bumps version in pyproject.toml to v0.2.6-alpha.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SciDataLib"
-version = "0.2.5"
+version = "0.2.6-alpha.1"
 description = "Python library for development of SciData JSON-LD files"
 authors = [
     "Stuart Chalk <schalk@unf.edu>",


### PR DESCRIPTION
Setting version to v0.2.6-alpha.1 so can pre-release off of `next` branch

@JohnsonDylan adding you for review but mainly to let you know this is going in, no real review needed. thanks!