### PR TITLE
Moves pytest-cov to a dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ scidatalib = "scidatalib.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pytest-cov = ">=2.11.1"
 numpy = "^1.20.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
+pytest-cov = ">=2.11.1"
 flake8 = "^3.8.4"
 
 [build-system]


### PR DESCRIPTION
Moves pytest-cov to dev dependency.

Currently, it gets installed with the PyPi package version, which we don't need at runtime, only dev time